### PR TITLE
Read second channel from \buf2

### DIFF
--- a/classes/ZEcho.sc
+++ b/classes/ZEcho.sc
@@ -142,7 +142,7 @@ ZEchoDefaultGranular : ZEcho {
 				BufGrain.ar(
 					grainTrigger,
 					\grainDuration.kr(0.2),
-					\buf1.kr,
+					\buf2.kr,
 					\rate.kr(1),
 					readPos,
 					4


### PR DESCRIPTION
I think the `grains` array is reading in from `\buf1` twice, rather than reading from both input buffers.